### PR TITLE
Update membership.json

### DIFF
--- a/resources/membership.json
+++ b/resources/membership.json
@@ -396,10 +396,10 @@
 		"github_username": "chenxin-source"
 	},
 	"70": {
-		"domain": "hanta.us.kg",
+		"domain": "blog.hanta2011.top",
 		"icon": "https://pic.imgdb.cn/item/65fe67989f345e8d03923ea6.jpg",
 		"name": "可执行程序の天境小屋🥝",
-		"description": "苦恼于空岛物资不足的学生党",
+		"description": "The boy who lived",
 		"github_username": "exef-star"
 	}
 }


### PR DESCRIPTION
### 修改第70个`可执行程序の天境小屋🥝`（原域名为`hanta.us.kg`）域名为`blog.hanta2011.top`

#### 原因

原博客域名更换，可访问网站以获取详细信息

#### 修改项

- 网站url
- 网站描述